### PR TITLE
Allow dots in Month and Day pattern

### DIFF
--- a/switchdatetime/src/main/java/com/kunzisoft/switchdatetime/SwitchDateTimeDialogFragment.java
+++ b/switchdatetime/src/main/java/com/kunzisoft/switchdatetime/SwitchDateTimeDialogFragment.java
@@ -542,7 +542,7 @@ public class SwitchDateTimeDialogFragment extends DialogFragment {
      * @param simpleDateFormat Format to show month and day
      */
     public void setSimpleDateMonthAndDayFormat(SimpleDateFormat simpleDateFormat) throws SimpleDateMonthAndDayFormatException{
-        Pattern patternMonthAndDay = Pattern.compile("(M|w|W|D|d|F|E|u|\\s)*");
+        Pattern patternMonthAndDay = Pattern.compile("(M|w|W|D|d|F|E|u|\\.|\\s)*");
         Matcher matcherMonthAndDay = patternMonthAndDay.matcher(simpleDateFormat.toPattern());
         if(!matcherMonthAndDay.matches()) {
             throw new SimpleDateMonthAndDayFormatException(simpleDateFormat.toPattern() + "isn't allowed for " + patternMonthAndDay.pattern());


### PR DESCRIPTION
In German, the common pattern for displaying dates and months is `d. MMMM` or `dd. MMMM`, like `18. September`. The library currently rejects dots. Since I don't see a particular reason for rejecting them, I'd be happy if you accept this tiny PR. If there is a reason to only allow whitespaces besides the formatting letters, just close the PR.
Thanks for your work on this useful library!